### PR TITLE
Have a more flexible peer dependency on react

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "webpack-hot-middleware": "^2.7.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": ">=0.14.0"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
This gets rid of the warning that react 16 is an incompatible peer dependency, even though it is actually perfectly compatible.